### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "genericons",
+  "version": "1.0.0",
+  "description": "Genericons are vector icons embedded in a webfont designed to be clean and simple keeping with a generic aesthetic. Use for instant HiDPI or to easily change colors on the fly.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/Genericons.git"
+  },
+  "keywords": [
+    "icon",
+    "font",
+    "blog"
+  ],
+  "author": "George Stephanis <georgestephanis@automattic.com>",
+  "license": "GPL-2.0",
+  "bugs": {
+    "url": "https://github.com/Automattic/Genericons/issues"
+  },
+  "homepage": "https://github.com/Automattic/Genericons#readme"
+}


### PR DESCRIPTION
Add package.json so that genericons can be included in other npm projects. 

This is to support a React-based set of components that were previously using a proprietary icon font, but I want to open-source.