### PR TITLE
Update genericons.css to fix 'Unexpected CSS Token' warnings

### DIFF
--- a/genericons/genericons.css
+++ b/genericons/genericons.css
@@ -68,7 +68,7 @@
 	-ms-transform: rotate(90deg);
 	-o-transform: rotate(90deg);
 	transform: rotate(90deg);
-	filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
+	filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
 }
 
 .genericon-rotate-180 {
@@ -77,7 +77,7 @@
 	-ms-transform: rotate(180deg);
 	-o-transform: rotate(180deg);
 	transform: rotate(180deg);
-	filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+	filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
 }
 
 .genericon-rotate-270 {
@@ -86,7 +86,7 @@
 	-ms-transform: rotate(270deg);
 	-o-transform: rotate(270deg);
 	transform: rotate(270deg);
-	filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+	filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
 }
 
 .genericon-flip-horizontal {


### PR DESCRIPTION
Getting 'Unexpected CSS Token :' warnings on ie8 filters. Fixed by quoting the filter statements (lines 71, 80, and 89).