### PR TITLE
fix: JavaFx compatibility

### DIFF
--- a/genericons/genericons.css
+++ b/genericons/genericons.css
@@ -44,7 +44,7 @@
 	-moz-transition: color .1s ease-in 0;
 	-webkit-transition: color .1s ease-in 0;
 	display: inline-block;
-	font-family: "Genericons";
+	font-family: "Genericons", serif;
 	font-style: normal;
 	font-weight: normal;
 	font-variant: normal;

--- a/source/fontcustom-templates/genericons.css
+++ b/source/fontcustom-templates/genericons.css
@@ -23,7 +23,7 @@
 	-moz-transition: color .1s ease-in 0;
 	-webkit-transition: color .1s ease-in 0;
 	display: inline-block;
-	font-family: "<%= font_name %>";
+	font-family: "<%= font_name %>", serif;
 	font-style: normal;
 	font-weight: normal;
 	font-variant: normal;

--- a/source/fontcustom-webfont/genericons.css
+++ b/source/fontcustom-webfont/genericons.css
@@ -44,7 +44,7 @@
 	-moz-transition: color .1s ease-in 0;
 	-webkit-transition: color .1s ease-in 0;
 	display: inline-block;
-	font-family: "Genericons";
+	font-family: "Genericons", serif;
 	font-style: normal;
 	font-weight: normal;
 	font-variant: normal;


### PR DESCRIPTION
Some navigators cannot have a fallback font if we already override the default font.
This is the case with the WebView of JavaFx.

For example :
```html
<html>
    <head>
        <meta charset="utf-8">
        <link rel="stylesheet" href="fonts/genericons.css">
    </head>
    <body>
        <div class="genericon genericon-home">Hello, World!</div>
        <div class="genericon genericon-home">你好，世界</div>
    </body>
</html>
```

Here, the text inside the div failed to render because of :
```css
font-family: "Genericons"
```

This PR add a fallback to serif font, so we can still render a text inside Genericons's divs.